### PR TITLE
Add DigitalOcean bin

### DIFF
--- a/lib/fog/bin/digitalocean.rb
+++ b/lib/fog/bin/digitalocean.rb
@@ -1,0 +1,30 @@
+class DigitalOcean < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::DigitalOcean
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("DigitalOcean[:compute] is not recommended, use Compute[:digitalocean] for portability")
+          Fog::Compute.new(:provider => 'DigitalOcean')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::DigitalOcean.services
+    end
+  end
+end
+


### PR DESCRIPTION
Providers need this added to run properly. This was removed properly
from the fog/fog repository, but it was not added to this provider gem.
