### PR TITLE
Fix the get_image_details mock.

### DIFF
--- a/lib/fog/digitalocean/requests/compute/get_image_details.rb
+++ b/lib/fog/digitalocean/requests/compute/get_image_details.rb
@@ -13,26 +13,32 @@ module Fog
 
       # noinspection RubyStringKeysInHashInspection
       class Mock
-        def get_image_details(_)
+        def get_image_details(id_or_slug)
           response        = Excon::Response.new
-          response.status = 200
 
-          response.body = {
-            'image' =>
-            {
-              'id' => 7555620,
-              'name' => 'Nifty New Snapshot',
-              'distribution' => 'Ubuntu',
-              'slug' => nil,
-              'public' => false,
-              'regions' => [
-                'nyc2',
-                'nyc2'
-                ],
-                'created_at' => '2014-11-04T22:23:02Z',
-                'min_disk_size' => 20
+          if [7555620, 'nifty-new-snapshot-ubuntu'].include?(id_or_slug)
+            response.status = 200
+
+            response.body = {
+              'image' =>
+              {
+                'id' => 7555620,
+                'name' => 'Nifty New Snapshot',
+                'distribution' => 'Ubuntu',
+                'slug' => 'nifty-new-snapshot-ubuntu',
+                'public' => false,
+                'regions' => [
+                  'nyc2',
+                  'nyc2'
+                  ],
+                  'created_at' => '2014-11-04T22:23:02Z',
+                  'min_disk_size' => 20
+                }
               }
-            }
+          else
+            response.status = 404
+            raise(Fog::Compute::DigitalOcean::NotFound.new("Expected([200]) <=> Actual(404 Not Found)"))
+          end
 
           response
         end

--- a/lib/fog/digitalocean/requests/compute/list_images.rb
+++ b/lib/fog/digitalocean/requests/compute/list_images.rb
@@ -24,7 +24,7 @@ module Fog
                 'id'            => 7555620,
                 'name'          => 'Nifty New Snapshot',
                 'distribution'  => 'Ubuntu',
-                'slug'          => nil,
+                'slug'          => 'nifty-new-snapshot-ubuntu',
                 'public'        => false,
                 'regions'       => %w(nyc2 nyc3),
                 'created_at'    => '2014-11-04T22:23:02Z',


### PR DESCRIPTION
The mock request completely ignored the parameter (an image's ID or slug) and simply always returned a 200, meaning it would return an incorrect result in most cases.