### PR TITLE
Fix pagination in the mock list_images request.

### DIFF
--- a/lib/fog/digitalocean/requests/compute/list_images.rb
+++ b/lib/fog/digitalocean/requests/compute/list_images.rb
@@ -15,6 +15,8 @@ module Fog
       # noinspection RubyStringKeysInHashInspection
       class Mock
         def list_images(filters = {})
+          next_page = (filters[:page] || 1).to_i + 1
+
           response        = Excon::Response.new
           response.status = 200
           response.body   = {
@@ -35,7 +37,7 @@ module Fog
             'links'  => {
               'pages' => {
                 'last' => 'https://api.digitalocean.com/v2/images?page=56&per_page=1',
-                'next' => 'https://api.digitalocean.com/v2/images?page=2&per_page=1'
+                'next' => "https://api.digitalocean.com/v2/images?page=#{next_page}&per_page=1"
               }
             },
             'meta'   => {


### PR DESCRIPTION
Prior to this change, the 'next page' link never updated, so any code that relied on the pagination state updating on each request would get stuck in an infinite loop.